### PR TITLE
omit jax dependancy

### DIFF
--- a/lru/scan_utils.py
+++ b/lru/scan_utils.py
@@ -1,10 +1,10 @@
 # Pytorch port of associative scan
 
 #@title PyTorch associative/parallel scan
-# Taken from https://github.com/i404788/s5-pytorch/blob/74e2fdae00b915a62c914bf3615c0b8a4279eb84/s5/jax_compat.py#L50-L134
+# Taken from https://github.com/i404788/s5-pytorch/blob/c74be7270fe2ec9dc13efcffcfd7f5355d884030/s5/jax_compat.py
 import torch
-from jax.tree_util import tree_flatten, tree_unflatten
-from typing import overload, Callable, Iterable, List, TypeVar, Any, Literal, Union, Sequence, Tuple, Optional
+from torch.utils._pytree import tree_flatten, tree_unflatten
+from typing import overload, Callable, Iterable, List, TypeVar, Any,Tuple
 from functools import partial
 
 """
@@ -43,25 +43,57 @@ def safe_map(f, *args):
     return list(map(f, *args))
 
 
-def slice_along_axis(start, end, stride=None, axis=0):
-    return (slice(None),) * axis + (slice(start, end, stride),)
+def combine(tree, operator, a_flat, b_flat):
+    # Lower `fn` to operate on flattened sequences of elems.
+    a = tree_unflatten(a_flat, tree)
+    b = tree_unflatten(b_flat, tree)
+    c = operator(a, b)
+    c_flat, _ = tree_flatten(c)
+    return c_flat
 
-# Pytorch impl. of jax.lax.associative_scan
-def associative_scan(operator, elems, axis=0, reverse=False):
-    if not callable(operator):
-        raise TypeError("lax.associative_scan: fn argument should be callable.")
+
+def _scan(tree, operator, elems, axis: int):
+    """Perform scan on `elems`."""
+    num_elems = elems[0].shape[axis]
+
+    if num_elems < 2:
+        return elems
+
+    # Combine adjacent pairs of elements.
+    reduced_elems = combine(tree, operator,
+                            [torch.ops.aten.slice(elem, axis, 0, -1, 2) for elem in elems],
+                            [torch.ops.aten.slice(elem, axis, 1, None, 2) for elem in elems])
+
+    # Recursively compute scan for partially reduced tensors.
+    odd_elems = _scan(tree, operator, reduced_elems, axis)
+
+    if num_elems % 2 == 0:
+        even_elems = combine(tree, operator,
+                             [torch.ops.aten.slice(e, axis, 0, -1) for e in odd_elems],
+                             [torch.ops.aten.slice(e, axis, 2, None, 2) for e in elems])
+    else:
+        even_elems = combine(tree, operator,
+                             odd_elems,
+                             [torch.ops.aten.slice(e, axis, 2, None, 2) for e in elems])
+
+    # The first element of a scan is the same as the first element
+    # of the original `elems`.
+    even_elems = [
+        torch.cat([torch.ops.aten.slice(elem, axis, 0, 1), result], dim=axis)
+        if result.shape.numel() > 0 and elem.shape[axis] > 0 else
+        result if result.shape.numel() > 0 else
+        torch.ops.aten.slice(elem, axis, 0, 1)  # Jax allows/ignores concat with 0-dim, Pytorch does not
+        for (elem, result) in zip(elems, even_elems)]
+
+    return list(safe_map(partial(_interleave, axis=axis), even_elems, odd_elems))
+
+
+def associative_scan(operator: Callable, elems, axis: int = 0, reverse: bool = False):
+
     elems_flat, tree = tree_flatten(elems)
 
     if reverse:
         elems_flat = [torch.flip(elem, [axis]) for elem in elems_flat]
-
-    def combine(a_flat, b_flat):
-        # Lower `fn` to operate on flattened sequences of elems.
-        a = tree_unflatten(tree, a_flat)
-        b = tree_unflatten(tree, b_flat)
-        c = operator(a, b)
-        c_flat, _ = tree_flatten(c)
-        return c_flat
 
     assert axis >= 0 or axis < elems_flat[0].ndim, "Axis should be within bounds of input"
     num_elems = int(elems_flat[0].shape[axis])
@@ -70,47 +102,14 @@ def associative_scan(operator, elems, axis=0, reverse=False):
                          'first dimension. (saw: {})'
                          .format([elem.shape for elem in elems_flat]))
 
-    def _scan(elems):
-        """Perform scan on `elems`."""
-        num_elems = elems[0].shape[axis]
-
-        if num_elems < 2:
-            return elems
-
-        # Combine adjacent pairs of elements.
-        reduced_elems = combine(
-          [elem[slice_along_axis(0, -1, stride=2, axis=axis)] for elem in elems],
-          [elem[slice_along_axis(1, None, stride=2, axis=axis)] for elem in elems])
-
-        # Recursively compute scan for partially reduced tensors.
-        odd_elems = _scan(reduced_elems)
-
-        if num_elems % 2 == 0:
-            even_elems = combine(
-                [e[slice_along_axis(0, -1, axis=axis)] for e in odd_elems],
-                [e[slice_along_axis(2, None, stride=2, axis=axis)] for e in elems])
-        else:
-            even_elems = combine(
-                odd_elems,
-                [e[slice_along_axis(2, None, stride=2, axis=axis)] for e in elems])
-
-        # The first element of a scan is the same as the first element
-        # of the original `elems`.
-        even_elems = [
-          torch.cat([elem[slice_along_axis(0, 1, axis=axis)], result], dim=axis)
-          if result.shape.numel() > 0 and elem.shape[axis] > 0 else
-          result if result.shape.numel() > 0 else
-          elem[slice_along_axis(0, 1, axis=axis)]  # Jax allows/ignores concat with 0-dim, Pytorch does not
-          for (elem, result) in zip(elems, even_elems)]
-
-        return list(safe_map(partial(_interleave, axis=axis), even_elems, odd_elems))
-
-    scans = _scan(elems_flat)
+    scans = _scan(tree, operator, elems_flat, axis)
 
     if reverse:
         scans = [torch.flip(scanned, [axis]) for scanned in scans]
 
-    return tree_unflatten(tree, scans)
+    return tree_unflatten(scans, tree)
+
+
 
 
 def _interleave(a, b, axis):
@@ -124,7 +123,7 @@ def _interleave(a, b, axis):
     interleaved = torch.flatten(stacked, start_dim=axis, end_dim=axis+1)
     if b_trunc:
         # TODO: find torch alternative for slice_along axis for torch.jit.script to work
-        interleaved = interleaved[slice_along_axis(0, b.shape[axis]+a.shape[axis]-1, axis=axis)]
+        interleaved = torch.ops.aten.slice(interleaved, axis, 0, b.shape[axis]+a.shape[axis]-1)
     return interleaved
 
 


### PR DESCRIPTION
Hi,

Summary: As mentioned in #1 we can do everything in PyTorch using the `torch.utils._pytree` functionality available in PyTorch 2.

Credit: I used the code from [here](https://github.com/i404788/s5-pytorch/blob/c74be7270fe2ec9dc13efcffcfd7f5355d884030/s5/jax_compat.py),


Tests: The `train`,` test` and `playground` scripts/notebooks still run fine with the updated code, and give similar results.